### PR TITLE
refactor: dedupe storage helpers into safeSession/safeLocal

### DIFF
--- a/lib/persona.ts
+++ b/lib/persona.ts
@@ -1,3 +1,4 @@
+import { safeLocal } from "./storage";
 import type { Persona } from "./types";
 
 const KEY = "gw:persona:v1";
@@ -8,24 +9,13 @@ export const DEFAULT_PERSONA: Persona = {
 };
 
 export function loadPersona(): Persona {
-  if (typeof window === "undefined") return DEFAULT_PERSONA;
-  try {
-    const raw = window.localStorage.getItem(KEY);
-    if (!raw) return DEFAULT_PERSONA;
-    const parsed = JSON.parse(raw) as Partial<Persona>;
-    return { ...DEFAULT_PERSONA, ...parsed };
-  } catch {
-    return DEFAULT_PERSONA;
-  }
+  const parsed = safeLocal.get<Partial<Persona>>(KEY);
+  if (!parsed) return DEFAULT_PERSONA;
+  return { ...DEFAULT_PERSONA, ...parsed };
 }
 
 export function savePersona(p: Persona): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(KEY, JSON.stringify(p));
-  } catch {
-    // ignore
-  }
+  safeLocal.set(KEY, p);
 }
 
 export function personaCacheKey(p: Persona): string {

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,0 +1,42 @@
+type StorageKind = "session" | "local";
+
+function store(kind: StorageKind): Storage | null {
+  if (typeof window === "undefined") return null;
+  return kind === "session" ? window.sessionStorage : window.localStorage;
+}
+
+function makeSafe(kind: StorageKind) {
+  return {
+    get<T>(key: string): T | null {
+      const s = store(kind);
+      if (!s) return null;
+      try {
+        const raw = s.getItem(key);
+        return raw ? (JSON.parse(raw) as T) : null;
+      } catch {
+        return null;
+      }
+    },
+    set<T>(key: string, value: T): void {
+      const s = store(kind);
+      if (!s) return;
+      try {
+        s.setItem(key, JSON.stringify(value));
+      } catch {
+        // ignore
+      }
+    },
+    remove(key: string): void {
+      const s = store(kind);
+      if (!s) return;
+      try {
+        s.removeItem(key);
+      } catch {
+        // ignore
+      }
+    },
+  };
+}
+
+export const safeSession = makeSafe("session");
+export const safeLocal = makeSafe("local");

--- a/lib/trail.ts
+++ b/lib/trail.ts
@@ -1,3 +1,4 @@
+import { safeSession } from "./storage";
 import type { Referrer } from "./types";
 
 const REFERRER_KEY = "gw:referrer:v1";
@@ -5,55 +6,26 @@ const TRAIL_KEY = "gw:trail:v1";
 const TRAIL_MAX = 20;
 
 export function getReferrer(): Referrer | null {
-  if (typeof window === "undefined") return null;
-  try {
-    const raw = window.sessionStorage.getItem(REFERRER_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as Referrer;
-    if (!parsed.slug || !parsed.body) return null;
-    return parsed;
-  } catch {
-    return null;
-  }
+  const parsed = safeSession.get<Referrer>(REFERRER_KEY);
+  if (!parsed || !parsed.slug || !parsed.body) return null;
+  return parsed;
 }
 
 export function setReferrer(r: Referrer): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.sessionStorage.setItem(REFERRER_KEY, JSON.stringify(r));
-  } catch {
-    // ignore
-  }
+  safeSession.set(REFERRER_KEY, r);
 }
 
 export function clearReferrer(): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.sessionStorage.removeItem(REFERRER_KEY);
-  } catch {
-    // ignore
-  }
+  safeSession.remove(REFERRER_KEY);
 }
 
 export function pushTrail(slug: string): void {
-  if (typeof window === "undefined") return;
-  try {
-    const raw = window.sessionStorage.getItem(TRAIL_KEY);
-    const arr: string[] = raw ? JSON.parse(raw) : [];
-    if (arr[arr.length - 1] !== slug) arr.push(slug);
-    while (arr.length > TRAIL_MAX) arr.shift();
-    window.sessionStorage.setItem(TRAIL_KEY, JSON.stringify(arr));
-  } catch {
-    // ignore
-  }
+  const arr = safeSession.get<string[]>(TRAIL_KEY) ?? [];
+  if (arr[arr.length - 1] !== slug) arr.push(slug);
+  while (arr.length > TRAIL_MAX) arr.shift();
+  safeSession.set(TRAIL_KEY, arr);
 }
 
 export function getTrail(): string[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const raw = window.sessionStorage.getItem(TRAIL_KEY);
-    return raw ? (JSON.parse(raw) as string[]) : [];
-  } catch {
-    return [];
-  }
+  return safeSession.get<string[]>(TRAIL_KEY) ?? [];
 }


### PR DESCRIPTION
## Summary
- New `lib/storage.ts` exposes `safeSession` and `safeLocal`, wrapping the SSR guard, try/catch, and JSON parse/stringify once.
- `lib/trail.ts` and `lib/persona.ts` now delegate to those helpers, shrinking each file and removing repeated boilerplate.
- Pure refactor, no behavior change. Closes #6.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` clean
- [ ] Manual smoke: persona persists across reload, trail/referrer persist within session