### PR TITLE
Clean up OpenRouter path: typed extras + prompt caching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ ANTHROPIC_MODEL=claude-sonnet-4-6
 
 # --- OpenRouter (fallback / temporary default) ---
 OPENROUTER_API_KEY=sk-or-v1-...
-OPENROUTER_MODEL=anthropic/claude-sonnet-4.6
+OPENROUTER_MODEL=google/gemini-3-flash-preview
 
 # Optional override: anthropic | openrouter
 # LLM_PROVIDER=openrouter

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -9,7 +9,7 @@ export const dynamic = "force-dynamic";
 
 const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL ?? "claude-sonnet-4-6";
 const OPENROUTER_MODEL =
-  process.env.OPENROUTER_MODEL ?? "anthropic/claude-sonnet-4.6";
+  process.env.OPENROUTER_MODEL ?? "google/gemini-3-flash-preview";
 const MAX_REFERRER_CHARS = 2000;
 const MAX_FREEFORM_CHARS = 500;
 const MAX_TOKENS = 800;
@@ -119,9 +119,6 @@ async function* streamFromAnthropic(apiKey: string, userMessage: string) {
   }
 }
 
-type CachedTextPart = OpenAI.Chat.ChatCompletionContentPartText & {
-  cache_control?: { type: "ephemeral" };
-};
 type OpenRouterExtras = {
   reasoning?: { enabled: boolean; exclude: boolean };
 };
@@ -137,19 +134,12 @@ async function* streamFromOpenRouter(apiKey: string, userMessage: string) {
     baseURL: "https://openrouter.ai/api/v1",
     defaultHeaders,
   });
-  const systemContent: CachedTextPart[] = [
-    {
-      type: "text",
-      text: SYSTEM_PROMPT,
-      cache_control: { type: "ephemeral" },
-    },
-  ];
   const body: OpenAI.Chat.ChatCompletionCreateParamsStreaming &
     OpenRouterExtras = {
     model: OPENROUTER_MODEL,
     max_tokens: MAX_TOKENS,
     messages: [
-      { role: "system", content: systemContent },
+      { role: "system", content: SYSTEM_PROMPT },
       { role: "user", content: userMessage },
     ],
     stream: true,

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -119,6 +119,9 @@ async function* streamFromAnthropic(apiKey: string, userMessage: string) {
   }
 }
 
+type CachedTextPart = OpenAI.Chat.ChatCompletionContentPartText & {
+  cache_control?: { type: "ephemeral" };
+};
 type OpenRouterExtras = {
   reasoning?: { enabled: boolean; exclude: boolean };
 };
@@ -134,12 +137,19 @@ async function* streamFromOpenRouter(apiKey: string, userMessage: string) {
     baseURL: "https://openrouter.ai/api/v1",
     defaultHeaders,
   });
+  const systemContent: CachedTextPart[] = [
+    {
+      type: "text",
+      text: SYSTEM_PROMPT,
+      cache_control: { type: "ephemeral" },
+    },
+  ];
   const body: OpenAI.Chat.ChatCompletionCreateParamsStreaming &
     OpenRouterExtras = {
     model: OPENROUTER_MODEL,
     max_tokens: MAX_TOKENS,
     messages: [
-      { role: "system", content: SYSTEM_PROMPT },
+      { role: "system", content: systemContent },
       { role: "user", content: userMessage },
     ],
     stream: true,

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -119,6 +119,13 @@ async function* streamFromAnthropic(apiKey: string, userMessage: string) {
   }
 }
 
+type CachedTextPart = OpenAI.Chat.ChatCompletionContentPartText & {
+  cache_control?: { type: "ephemeral" };
+};
+type OpenRouterExtras = {
+  reasoning?: { enabled: boolean; exclude: boolean };
+};
+
 async function* streamFromOpenRouter(apiKey: string, userMessage: string) {
   const defaultHeaders: Record<string, string> = {};
   if (process.env.OR_REFERER)
@@ -130,19 +137,25 @@ async function* streamFromOpenRouter(apiKey: string, userMessage: string) {
     baseURL: "https://openrouter.ai/api/v1",
     defaultHeaders,
   });
-  const response = await client.chat.completions.create({
+  const systemContent: CachedTextPart[] = [
+    {
+      type: "text",
+      text: SYSTEM_PROMPT,
+      cache_control: { type: "ephemeral" },
+    },
+  ];
+  const body: OpenAI.Chat.ChatCompletionCreateParamsStreaming &
+    OpenRouterExtras = {
     model: OPENROUTER_MODEL,
     max_tokens: MAX_TOKENS,
     messages: [
-      { role: "system", content: SYSTEM_PROMPT },
+      { role: "system", content: systemContent },
       { role: "user", content: userMessage },
     ],
     stream: true,
-    ...({ reasoning: { enabled: false, exclude: true } } as Record<
-      string,
-      unknown
-    >),
-  });
+    reasoning: { enabled: false, exclude: true },
+  };
+  const response = await client.chat.completions.create(body);
   for await (const chunk of response) {
     const text = chunk.choices[0]?.delta?.content;
     if (text) yield text;
@@ -173,17 +186,17 @@ export async function POST(req: Request) {
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
       const debug = process.env.LLM_DEBUG === "1";
-      const buf: string[] = [];
+      const buf: string[] | null = debug ? [] : null;
       try {
         const iter =
           picked.provider === "anthropic"
             ? streamFromAnthropic(picked.apiKey, userMessage)
             : streamFromOpenRouter(picked.apiKey, userMessage);
         for await (const text of iter) {
-          if (debug) buf.push(text);
+          buf?.push(text);
           controller.enqueue(encoder.encode(text));
         }
-        if (debug) {
+        if (buf) {
           console.log(
             `[gen ${picked.provider}/${slug}] ${buf.join("").slice(0, 2000)}`,
           );


### PR DESCRIPTION
## Summary
- Replace the `as Record<string, unknown>` spread for `reasoning` with a typed `OpenRouterExtras` intersection, so the field is type-checked instead of escaping the type system (#11).
- Only allocate the `LLM_DEBUG` buffer when `debug` is on (#11).
- Switch OpenRouter default model to `google/gemini-3-flash-preview` (#12). Gemini 3 Flash has `supports_implicit_caching: true` on OR, so prompt prefixes are cached automatically Google-side with no `cache_control` needed.

### Why not `cache_control` on Anthropic via OR?
Initial impl wrapped `SYSTEM_PROMPT` in a content block with `cache_control: { type: "ephemeral" }` for the OR path. Smoke tests against `anthropic/claude-sonnet-4.6` showed the field was reaching OR (verified via body dump), but `cache_write_tokens` stayed at 0 across repeat requests. Forcing `provider.only=["anthropic"]` returned 404 — that model has no Anthropic-direct endpoint on OR, only Bedrock/Vertex routes which silently strip `cache_control`. Gemini's implicit caching sidesteps the issue.

Closes #11, #12.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bunx oxlint app/api/generate/route.ts` clean
- [x] OR path streaming via curl (Gemini 3 Flash) — full article body, ~1KB, frontmatter intact.
- [x] `LLM_DEBUG=1` → `[gen openrouter/<slug>] ...` log line printed; unset → `buf` stays `null`.
- [ ] Anthropic path unchanged — covered by code (anthropic branch untouched aside from existing `cache_control`).
- [ ] Cache hit verification: requires checking OR dashboard cached-input-tokens column on 2 successive same-prompt reqs (Google implicit cache).