### PR TITLE
test: unit tests for parser, sanitizers, and persona cache key

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -48,14 +48,14 @@ type GenerateBody = {
   referrer?: unknown;
 };
 
-function sanitizeSlug(raw: unknown): string {
+export function sanitizeSlug(raw: unknown): string {
   if (typeof raw !== "string") return "";
   const trimmed = raw.trim().slice(0, 100);
   if (trimmed === HOME_SLUG) return trimmed;
   return trimmed.toLowerCase().replace(/[^a-z0-9_-]/g, "");
 }
 
-function sanitizePersona(raw: unknown): Persona {
+export function sanitizePersona(raw: unknown): Persona {
   const def: Persona = { level: "general", chaos: "off" };
   if (!raw || typeof raw !== "object") return def;
   const o = raw as Record<string, unknown>;
@@ -84,7 +84,7 @@ function sanitizePersona(raw: unknown): Persona {
   return { level, chaos, freeform, chaosCustom };
 }
 
-function sanitizeReferrer(raw: unknown): Referrer | null {
+export function sanitizeReferrer(raw: unknown): Referrer | null {
   if (!raw || typeof raw !== "object") return null;
   const o = raw as Record<string, unknown>;
   if (typeof o.slug !== "string" || typeof o.body !== "string") return null;

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/bun": "^1.3.13",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -223,6 +224,8 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.2.4", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.2.4", "@tailwindcss/oxide": "4.2.4", "postcss": "^8.5.6", "tailwindcss": "4.2.4" } }, "sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg=="],
 
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
     "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
     "@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
@@ -234,6 +237,8 @@
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.25", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001791", "", {}, "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ=="],
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "oxlint",
     "fmt": "oxfmt",
-    "fmt:check": "oxfmt --check"
+    "fmt:check": "oxfmt --check",
+    "test": "bun test"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.92.0",
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/bun": "^1.3.13",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseFrontmatter,
+  slugToDisplay,
+  targetToSlug,
+  tokenizeBody,
+} from "@/lib/parse";
+
+describe("parseFrontmatter", () => {
+  test("valid article", () => {
+    const text = `---\ntype: article\ntitle: Hello World\n---\nbody here`;
+    const r = parseFrontmatter(text);
+    expect(r).not.toBeNull();
+    expect(r!.fm).toEqual({ type: "article", title: "Hello World" });
+    expect(text.slice(r!.bodyStart)).toBe("body here");
+  });
+
+  test("valid rejected with reason and suggestions", () => {
+    const text = `---\ntype: rejected\nreason: too vague\nsuggestions:\n  - foo\n  - bar\n---\n`;
+    const r = parseFrontmatter(text);
+    expect(r).not.toBeNull();
+    expect(r!.fm).toEqual({
+      type: "rejected",
+      reason: "too vague",
+      suggestions: ["foo", "bar"],
+    });
+  });
+
+  test("missing closing ---", () => {
+    const text = `---\ntype: article\ntitle: oops\n`;
+    expect(parseFrontmatter(text)).toBeNull();
+  });
+
+  test("malformed YAML", () => {
+    const text = `---\ntype: article\ntitle: "unterminated\n---\nbody`;
+    expect(parseFrontmatter(text)).toBeNull();
+  });
+
+  test("type !== article|rejected", () => {
+    const text = `---\ntype: bogus\ntitle: x\n---\nbody`;
+    expect(parseFrontmatter(text)).toBeNull();
+  });
+
+  test("no frontmatter at all", () => {
+    expect(parseFrontmatter("just body, no fm")).toBeNull();
+  });
+});
+
+describe("tokenizeBody", () => {
+  test("plain text", () => {
+    expect(tokenizeBody("hello world")).toEqual([
+      { type: "text", text: "hello world" },
+    ]);
+  });
+
+  test("single [[link]]", () => {
+    expect(tokenizeBody("a [[Foo]] b")).toEqual([
+      { type: "text", text: "a " },
+      { type: "link", target: "Foo" },
+      { type: "text", text: " b" },
+    ]);
+  });
+
+  test("multiple links", () => {
+    expect(tokenizeBody("[[A]] mid [[B C]]")).toEqual([
+      { type: "link", target: "A" },
+      { type: "text", text: " mid " },
+      { type: "link", target: "B C" },
+    ]);
+  });
+
+  test("unclosed [[", () => {
+    expect(tokenizeBody("text [[unclosed rest")).toEqual([
+      { type: "text", text: "text [[unclosed rest" },
+    ]);
+  });
+
+  test("empty", () => {
+    expect(tokenizeBody("")).toEqual([]);
+  });
+});
+
+describe("targetToSlug / slugToDisplay round-trip", () => {
+  test("simple words", () => {
+    const slug = targetToSlug("Hello World");
+    expect(slug).toBe("hello_world");
+    expect(slugToDisplay(slug)).toBe("hello world");
+  });
+
+  test("strips punctuation", () => {
+    expect(targetToSlug("Foo, Bar!")).toBe("foo_bar");
+  });
+
+  test("preserves hyphens and digits", () => {
+    expect(targetToSlug("UTF-8 Encoding 2")).toBe("utf-8_encoding_2");
+  });
+
+  test("collapses whitespace", () => {
+    expect(targetToSlug("  multi   space  ")).toBe("multi_space");
+  });
+
+  test("truncates to 100 chars", () => {
+    const slug = targetToSlug("a".repeat(150));
+    expect(slug.length).toBe(100);
+  });
+
+  test("slugToDisplay decodes percent-encoding", () => {
+    expect(slugToDisplay("caf%C3%A9_bar")).toBe("café bar");
+  });
+});

--- a/tests/persona.test.ts
+++ b/tests/persona.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { personaCacheKey } from "@/lib/persona";
+import type { Persona } from "@/lib/types";
+
+describe("personaCacheKey", () => {
+  test("same persona → same key", () => {
+    const a: Persona = { level: "general", chaos: "off" };
+    const b: Persona = { level: "general", chaos: "off" };
+    expect(personaCacheKey(a)).toBe(personaCacheKey(b));
+  });
+
+  test("differing freeform → different keys", () => {
+    const a: Persona = { level: "kid", chaos: "off", freeform: "hi" };
+    const b: Persona = { level: "kid", chaos: "off", freeform: "bye" };
+    expect(personaCacheKey(a)).not.toBe(personaCacheKey(b));
+  });
+
+  test("differing level → different keys", () => {
+    const a: Persona = { level: "kid", chaos: "off" };
+    const b: Persona = { level: "expert", chaos: "off" };
+    expect(personaCacheKey(a)).not.toBe(personaCacheKey(b));
+  });
+
+  test("differing chaos → different keys", () => {
+    const a: Persona = { level: "general", chaos: "shakespeare" };
+    const b: Persona = { level: "general", chaos: "linkedin" };
+    expect(personaCacheKey(a)).not.toBe(personaCacheKey(b));
+  });
+
+  test("custom chaos with differing chaosCustom → different keys", () => {
+    const a: Persona = { level: "general", chaos: "custom", chaosCustom: "x" };
+    const b: Persona = { level: "general", chaos: "custom", chaosCustom: "y" };
+    expect(personaCacheKey(a)).not.toBe(personaCacheKey(b));
+  });
+
+  test("undefined freeform === empty freeform", () => {
+    const a: Persona = { level: "general", chaos: "off" };
+    const b: Persona = { level: "general", chaos: "off", freeform: "" };
+    expect(personaCacheKey(a)).toBe(personaCacheKey(b));
+  });
+
+  test("freeform whitespace trimmed", () => {
+    const a: Persona = { level: "general", chaos: "off", freeform: " hi " };
+    const b: Persona = { level: "general", chaos: "off", freeform: "hi" };
+    expect(personaCacheKey(a)).toBe(personaCacheKey(b));
+  });
+});

--- a/tests/sanitize.test.ts
+++ b/tests/sanitize.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import {
+  sanitizePersona,
+  sanitizeReferrer,
+  sanitizeSlug,
+} from "@/app/api/generate/route";
+import { HOME_SLUG } from "@/lib/types";
+
+describe("sanitizeSlug", () => {
+  test("non-string → empty", () => {
+    expect(sanitizeSlug(undefined)).toBe("");
+    expect(sanitizeSlug(null)).toBe("");
+    expect(sanitizeSlug(42)).toBe("");
+    expect(sanitizeSlug({})).toBe("");
+  });
+
+  test("HOME_SLUG passthrough", () => {
+    expect(sanitizeSlug(HOME_SLUG)).toBe(HOME_SLUG);
+  });
+
+  test("lowercases and strips disallowed", () => {
+    expect(sanitizeSlug("Hello World!")).toBe("helloworld");
+    expect(sanitizeSlug("foo-bar_baz")).toBe("foo-bar_baz");
+  });
+
+  test("trims and caps at 100 chars", () => {
+    expect(sanitizeSlug("  abc  ")).toBe("abc");
+    expect(sanitizeSlug("a".repeat(150)).length).toBe(100);
+  });
+
+  test("empty string", () => {
+    expect(sanitizeSlug("")).toBe("");
+  });
+});
+
+describe("sanitizePersona", () => {
+  test("non-object → defaults", () => {
+    expect(sanitizePersona(null)).toEqual({ level: "general", chaos: "off" });
+    expect(sanitizePersona("hi")).toEqual({ level: "general", chaos: "off" });
+    expect(sanitizePersona(undefined)).toEqual({
+      level: "general",
+      chaos: "off",
+    });
+  });
+
+  test("invalid level/chaos fall back to defaults", () => {
+    const r = sanitizePersona({ level: "wizard", chaos: "doom" });
+    expect(r.level).toBe("general");
+    expect(r.chaos).toBe("off");
+  });
+
+  test("valid level and chaos preserved", () => {
+    const r = sanitizePersona({ level: "expert", chaos: "shakespeare" });
+    expect(r).toEqual({
+      level: "expert",
+      chaos: "shakespeare",
+      freeform: undefined,
+      chaosCustom: undefined,
+    });
+  });
+
+  test("oversized freeform truncated to 500", () => {
+    const r = sanitizePersona({
+      level: "kid",
+      chaos: "off",
+      freeform: "x".repeat(700),
+    });
+    expect(r.freeform!.length).toBe(500);
+  });
+
+  test("oversized chaosCustom truncated to 200", () => {
+    const r = sanitizePersona({
+      level: "general",
+      chaos: "custom",
+      chaosCustom: "y".repeat(400),
+    });
+    expect(r.chaosCustom!.length).toBe(200);
+  });
+
+  test("non-string freeform/chaosCustom → undefined", () => {
+    const r = sanitizePersona({
+      level: "general",
+      chaos: "off",
+      freeform: 123,
+      chaosCustom: {},
+    });
+    expect(r.freeform).toBeUndefined();
+    expect(r.chaosCustom).toBeUndefined();
+  });
+});
+
+describe("sanitizeReferrer", () => {
+  test("non-object → null", () => {
+    expect(sanitizeReferrer(null)).toBeNull();
+    expect(sanitizeReferrer("hi")).toBeNull();
+    expect(sanitizeReferrer(undefined)).toBeNull();
+  });
+
+  test("missing slug or body → null", () => {
+    expect(sanitizeReferrer({ slug: "x" })).toBeNull();
+    expect(sanitizeReferrer({ body: "y" })).toBeNull();
+    expect(sanitizeReferrer({ slug: "x", body: 1 })).toBeNull();
+  });
+
+  test("empty slug or body → null", () => {
+    expect(sanitizeReferrer({ slug: "", body: "y" })).toBeNull();
+    expect(sanitizeReferrer({ slug: "x", body: "" })).toBeNull();
+  });
+
+  test("valid passthrough", () => {
+    expect(sanitizeReferrer({ slug: "foo", body: "hello" })).toEqual({
+      slug: "foo",
+      body: "hello",
+    });
+  });
+
+  test("oversized slug capped at 100, body capped at 2000", () => {
+    const r = sanitizeReferrer({
+      slug: "a".repeat(150),
+      body: "b".repeat(3000),
+    });
+    expect(r!.slug.length).toBe(100);
+    expect(r!.body.length).toBe(2000);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #7. Adds unit tests for the parts that burned us during review: `lib/parse.ts` (parseFrontmatter, tokenizeBody, slug round-trip), the `app/api/generate/route.ts` sanitizers (slug/persona/referrer), and `lib/persona.ts:personaCacheKey`. Sanitizers exported so tests can import them; `@types/bun` added; `bun test` wired as the `test` script.

## Test plan
- [ ] `bun test` → 40 pass
- [ ] `bun run lint` clean
- [ ] `bunx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)