### PR TITLE
fix: unify slug normalization, guard decode, escape stream errors

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -1,10 +1,14 @@
 import { Article } from "@/components/Article";
-import { HOME_SLUG } from "@/lib/types";
+import { normalizeSlug } from "@/lib/slug";
 
 export default async function ArticlePage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug: rawSlug } = await params;
-  const decoded = decodeURIComponent(rawSlug).slice(0, 100);
-  const normalized =
-    decoded === HOME_SLUG ? HOME_SLUG : decoded.toLowerCase().replace(/[^a-z0-9_-]/g, "");
-  return <Article slug={normalized || decoded} />;
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(rawSlug);
+  } catch {
+    decoded = rawSlug;
+  }
+  const normalized = normalizeSlug(decoded);
+  return <Article slug={normalized} />;
 }

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -1,8 +1,8 @@
 import Anthropic from "@anthropic-ai/sdk";
 import OpenAI from "openai";
 import { SYSTEM_PROMPT, buildUserMessage } from "@/lib/prompts";
+import { normalizeSlug } from "@/lib/slug";
 import type { Persona, Referrer } from "@/lib/types";
-import { HOME_SLUG } from "@/lib/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -49,10 +49,11 @@ type GenerateBody = {
 };
 
 export function sanitizeSlug(raw: unknown): string {
-  if (typeof raw !== "string") return "";
-  const trimmed = raw.trim().slice(0, 100);
-  if (trimmed === HOME_SLUG) return trimmed;
-  return trimmed.toLowerCase().replace(/[^a-z0-9_-]/g, "");
+  return normalizeSlug(raw);
+}
+
+function escapeStreamMessage(message: string): string {
+  return message.replace(/\r?\n/g, " ").replace(/-{3,}/g, "—").slice(0, 500);
 }
 
 export function sanitizePersona(raw: unknown): Persona {
@@ -203,7 +204,8 @@ export async function POST(req: Request) {
         }
         controller.close();
       } catch (err) {
-        const message = err instanceof Error ? err.message : "unknown error";
+        const raw = err instanceof Error ? err.message : "unknown error";
+        const message = escapeStreamMessage(raw);
         controller.enqueue(
           encoder.encode(
             `---\ntype: rejected\nreason: error\nsuggestions: []\n---\nGeneration failed: ${message}`,

--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -1,4 +1,5 @@
 import yaml from "js-yaml";
+import { normalizeSlug } from "./slug";
 import type { Frontmatter } from "./types";
 
 export type ParsedHead = {
@@ -80,12 +81,7 @@ export function tokenizeBody(body: string): Segment[] {
 }
 
 export function targetToSlug(target: string): string {
-  return target
-    .trim()
-    .toLowerCase()
-    .replace(/\s+/g, "_")
-    .replace(/[^a-z0-9_-]/g, "")
-    .slice(0, 100);
+  return normalizeSlug(target);
 }
 
 export function slugToDisplay(slug: string): string {

--- a/lib/slug.ts
+++ b/lib/slug.ts
@@ -1,0 +1,14 @@
+import { HOME_SLUG } from "./types";
+
+const MAX_SLUG_CHARS = 100;
+
+export function normalizeSlug(raw: unknown): string {
+  if (typeof raw !== "string") return "";
+  const trimmed = raw.trim();
+  if (trimmed === HOME_SLUG) return HOME_SLUG;
+  return trimmed
+    .toLowerCase()
+    .replace(/\s+/g, "_")
+    .replace(/[^a-z0-9_-]/g, "")
+    .slice(0, MAX_SLUG_CHARS);
+}

--- a/tests/sanitize.test.ts
+++ b/tests/sanitize.test.ts
@@ -18,9 +18,15 @@ describe("sanitizeSlug", () => {
     expect(sanitizeSlug(HOME_SLUG)).toBe(HOME_SLUG);
   });
 
-  test("lowercases and strips disallowed", () => {
-    expect(sanitizeSlug("Hello World!")).toBe("helloworld");
+  test("lowercases, spaces→_, strips disallowed", () => {
+    expect(sanitizeSlug("Hello World!")).toBe("hello_world");
     expect(sanitizeSlug("foo-bar_baz")).toBe("foo-bar_baz");
+  });
+
+  test("matches targetToSlug for same input", async () => {
+    const { targetToSlug } = await import("@/lib/parse");
+    expect(sanitizeSlug("Hello World")).toBe(targetToSlug("Hello World"));
+    expect(sanitizeSlug("UTF-8 Encoding 2")).toBe(targetToSlug("UTF-8 Encoding 2"));
   });
 
   test("trims and caps at 100 chars", () => {


### PR DESCRIPTION
## Summary
Closes #1. Cluster of slug + API error-path correctness fixes.

- New `lib/slug.ts:normalizeSlug` replaces three drifting implementations (page route, `targetToSlug`, API `sanitizeSlug`) so client URL and server cache key agree on the same input.
- `app/[slug]/page.tsx` wraps `decodeURIComponent` in try/catch (malformed `%`-sequences no longer 500) and drops the raw-decoded fallback that bypassed sanitization.
- `app/api/generate/route.ts` strips newlines and `---` runs from error messages before interpolating into the synthetic rejected-frontmatter so a thrown message can't corrupt the parser.
- Test updated for new space→`_` behavior; added cross-check that `sanitizeSlug` and `targetToSlug` agree.

## Test plan
- [x] `bun test` (41 pass)
- [x] `bunx tsc --noEmit` clean
- [x] Manual: visit `/%E0%A4%A` — no 500
- [x] Manual: `[[Hello World]]` link target matches direct `/hello_world` URL cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)