### PR TITLE
fix: settings popover regen without reload, narrow-viewport clamp (#4)

### DIFF
--- a/components/Article.tsx
+++ b/components/Article.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { getCached, putCached } from "@/lib/cache";
 import {
   isErrorEnvelope,
@@ -11,6 +11,7 @@ import {
   type ParsedHead,
 } from "@/lib/parse";
 import { loadPersona, personaCacheKey } from "@/lib/persona";
+import { PERSONA_CHANGE_EVENT } from "@/lib/personaEvents";
 import { clearReferrer, getReferrer, pushTrail, setReferrer } from "@/lib/trail";
 import { HOME_SLUG, type Frontmatter } from "@/lib/types";
 import { Settings } from "./Settings";
@@ -32,10 +33,23 @@ export function Article({ slug }: { slug: string }) {
   const [text, setText] = useState("");
   const [done, setDone] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [personaTick, setPersonaTick] = useState(0);
+  const consumedTick = useRef(0);
+
+  useEffect(() => {
+    function onPersonaChange() {
+      firstRender = false;
+      setPersonaTick((t) => t + 1);
+    }
+    window.addEventListener(PERSONA_CHANGE_EVENT, onPersonaChange);
+    return () => window.removeEventListener(PERSONA_CHANGE_EVENT, onPersonaChange);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
     let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+    const bypassCache = personaTick !== consumedTick.current;
+    consumedTick.current = personaTick;
 
     setText("");
     setDone(false);
@@ -46,7 +60,7 @@ export function Article({ slug }: { slug: string }) {
       const persona = loadPersona();
       const pkey = personaCacheKey(persona);
 
-      if (shouldUseCache()) {
+      if (!bypassCache && shouldUseCache()) {
         const cached = await getCached(slug, pkey);
         if (cancelled) return;
         if (cached && !isErrorEnvelope(parseFrontmatter(cached))) {
@@ -105,7 +119,7 @@ export function Article({ slug }: { slug: string }) {
       cancelled = true;
       reader?.cancel().catch(() => {});
     };
-  }, [slug]);
+  }, [slug, personaTick]);
 
   const parsed = useMemo(() => parseFrontmatter(text), [text]);
   const synthesized = !parsed && done && text.trim().length > 0;

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { DEFAULT_PERSONA, loadPersona, personaLabel, savePersona } from "@/lib/persona";
+import { PERSONA_CHANGE_EVENT } from "@/lib/personaEvents";
 import type { ChaosMode, Persona, ReadingLevel } from "@/lib/types";
 
 const CHAOS_OPTIONS: { value: ChaosMode; label: string }[] = [
@@ -44,7 +45,7 @@ export function Settings() {
     savePersona(draft);
     setPersona(draft);
     setOpen(false);
-    location.reload();
+    window.dispatchEvent(new CustomEvent(PERSONA_CHANGE_EVENT));
   }
 
   function cancel() {
@@ -59,14 +60,7 @@ export function Settings() {
         {persona.chaos !== "off" && (
           <>
             {" "}
-            · chaos:{" "}
-            <span className="font-semibold">
-              {persona.chaos === "custom"
-                ? `custom (${(persona.chaosCustom ?? "").slice(0, 24)}${
-                    (persona.chaosCustom ?? "").length > 24 ? "…" : ""
-                  })`
-                : persona.chaos}
-            </span>
+            · chaos: <span className="font-semibold">{renderChaosLabel(persona)}</span>
           </>
         )}
       </p>
@@ -77,7 +71,7 @@ export function Settings() {
       {open && (
         <div
           ref={popoverRef}
-          className="absolute right-0 top-8 z-20 w-80 rounded border border-[var(--rule)] bg-[var(--paper)] p-4 shadow-lg"
+          className="absolute right-0 top-8 z-20 w-80 max-w-[calc(100vw-2rem)] rounded border border-[var(--rule)] bg-[var(--paper)] p-4 shadow-lg"
         >
           <label className="block text-xs font-semibold uppercase tracking-wide text-zinc-600">
             Reading level
@@ -150,4 +144,10 @@ export function Settings() {
       )}
     </div>
   );
+}
+
+function renderChaosLabel(persona: Persona): string {
+  if (persona.chaos !== "custom") return persona.chaos;
+  const c = persona.chaosCustom ?? "";
+  return `custom (${c.slice(0, 24)}${c.length > 24 ? "…" : ""})`;
 }

--- a/lib/personaEvents.ts
+++ b/lib/personaEvents.ts
@@ -1,0 +1,1 @@
+export const PERSONA_CHANGE_EVENT = "persona-change";


### PR DESCRIPTION
## Summary
- `Settings.apply()` drops `location.reload()`; dispatches `persona-change` event so `Article` refetches in place (no app shell re-init, no killed stream).
- `Article` bumps a tick on the event; effect deps include the tick and bypass the IDB cache exactly once per apply (reroll intent).
- Popover gains `max-w-[calc(100vw-2rem)]` so the right-anchored fixed width clamps on narrow viewports.
- Chaos label ternary extracted to `renderChaosLabel(persona)`.

## Test plan
- [ ] Apply a persona change → article refetches without full page reload, stream restarts cleanly.
- [ ] Re-apply same persona → fresh generation (cache bypass).
- [ ] Navigate to a different slug after apply → IDB cache hit works (no unnecessary bypass).
- [ ] Resize to <320px → popover stays inside viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)